### PR TITLE
Fix extents-merge if range starts with 0

### DIFF
--- a/extents-merge
+++ b/extents-merge
@@ -17,7 +17,7 @@ sort -n |
 awk -e '
         BEGIN	{
         	start = -1;
-        	end = -1;
+        	end = -2;
 	}
 
                 {


### PR DESCRIPTION
If range starts with 0, the range gets wrong, as (0 <= end + 1) == true for end=-1. This is not uncommon, e.g.:

```
File size of /tmp/unittest/mnt_source/xxx.20190523/CREATE.TAG is 38 (1 block of 4096 bytes)
 ext:     logical_offset:        physical_offset: length:   expected: flags:
   0:        0..    4095:          0..      4095:   4096:             last,not_aligned,inline,eof
```